### PR TITLE
Noise veins

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ Etc.
 
 This plugin is fully configurable with biome-specific settings, tool restrictions, and limited player state restrictions, allowing a significant degree of options and specificity. 
 
+As of 1.5.2, you can upend this regime and construct intersecting probability fields via "Noise" generators, which allow a persistent hidden map of drop density regions. The probabilities are a bit harder to constrain, but still quite measurable with some trial and error. Unfortunately, due to the nature of noise generators, once you choose a config it will be difficult to rebalance smoothly -- e.g. player's discoveries of high density regions will likely be rendered invalid on a config change. The traditional probability approach doesn't really suffer from this as players would simply notice changes globally or within defined regions, and the "pain" would be shared, without impacting much secret knowledge. Regardless, both are excellent options for administrators and we're proud to finally support it on the mainline w/ all of our existing performance and anti-exploit features intact.
+
+Note that unlike other branches, our noise-based generation approach is embedded in the existing configuration flow, and is handled as a new feature regime instead of a completely "other" element. This allows you to freely mix and match these "veins", drops, transforms, commands and the like without loss of functionality. As always, the goal is max features and control for you.
+
 ## Details
 
 The raw technical details:
@@ -69,6 +73,10 @@ Supports saving and loading of the tracking database, and fully adheres to /relo
 
 As of 1.4.2, full multiple world support, via name or UUID. 
 
+As of 1.5.2, you can specify "veinNatures" which allow complex simplex-noise based distributions of ore probabilities. These are hard to compute as the mechanics aren't as straightforward, but the end result can be quite nice, allowing for layered, overlapping, or otherwise clever intersections of ores. Players like it too, as it allows a kind of density distribution, which once "found" can be leveraged. 
+
+In mainline as with all our other features, the full suite of configuration options, including drops, transforms, commands, biome and state modifiers, etc can be applied to veinNature configs. See config-veins.yml for examples.
+
 I'm probably missing some other details but that's it for now.
 
 ### TODO / In progress features:
@@ -77,9 +85,9 @@ I'm probably missing some other details but that's it for now.
 
 * Better documentation
 
-* 'Veins' -- adapting a popular feature from the CivClassic fork
-
 ### Feature Augment List:
+
+**v1.5.2** Adding in CivClassic style "veins", which are basically just distributions of ore backed by persistent noise fields instead of the classic HiddenOre probability distribution functions. The outcomes are probabilistically compatible, but the generation is quite a bit different. Check out config-veins.yml for a hopefully clear example. Note that due to fundamental implementation differences, configurations made for CivClassic veins are not portable to this implementation, as their implementation refactors the configs and introduces veins as a separate flow, with only some of the tradition drop or generation capabilities; our approach to veins preserves all the existing feature-rich environment and simply implements veins as a probability distribution modifier to existing drop configs (Expanding the features in 1.5.1 for global drop config design as well).
 
 **v1.5.1** Adding in a few key QoL features for continued 1.13 support. Specifically (and see config.yml for examples and details) you can now specify drops in a global section, and pick those drops by name in the block drop configurations. You can also specify multiple blocks for whom the drop config should apply, all in the same block config. This should allow significantly improved "terseness" to configs, above and beyond what the prior subtype system allowed. Note you can mix and match global drops and local drop configs for a block, but you cannot mix single or multiple block types for a single block config.
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.devotedmc</groupId>
     <artifactId>hiddenore</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2</version>
     <name>HiddenOre</name>
 
     <repositories>

--- a/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 
+import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.NamespacedKey;
 import org.bukkit.block.Block;
@@ -20,6 +21,7 @@ public class BlockConfig {
 	public boolean suppressDrops;
 	private Map<String, DropConfig> dropConfigs;
 	private String prefix;
+	private BlockConfigMode preferMode;
 
 	public BlockConfig(NamespacedKey material, boolean dropMultiple, boolean suppressDrops, String prefix, Collection<NamespacedKey> validGenTypes) {
 		this.material = material;
@@ -28,6 +30,15 @@ public class BlockConfig {
 		this.dropConfigs = new HashMap<String, DropConfig>();
 		this.prefix = prefix;
 		this.validGenTypes = validGenTypes;
+		this.preferMode = BlockConfigMode.both;
+	}
+	
+	public void setPreferMode(BlockConfigMode preferMode) {
+		this.preferMode = preferMode;
+	}
+	
+	public BlockConfigMode getPreferMode() {
+		return this.preferMode;
 	}
 
 	public NamespacedKey getMaterialKey() {
@@ -79,30 +90,53 @@ public class BlockConfig {
 	public DropConfig getDropConfig(String drop) {
 		return dropConfigs.get(drop);
 	}
+	
+	public boolean getForceVisibleTransform(String drop) {
+		DropConfig dc = getDropConfig(drop);
+		if (dc == null) return false;
+		VeinConfig vc = dc.getVeinNature();
+		if (vc == null) return false;
+		return vc.getForceVisibleTransform();
+	}
 
-	public String getDropConfig(double dice, String biome, ItemStack tool, Player player, int blockY) {
+	public String getDropConfig(double dice, String biome, ItemStack tool, Player player, Location loc) {
 		// accrue possible drops based on biome / tool
 		// check dice against stacked probabilities
 
 		double cumChance = 0.0d;
 		double localChance = 0.0d;
 		int counted = 0;
+		int blockY = loc.getBlockY();
 
-		for (Map.Entry<String, DropConfig> dc : dropConfigs.entrySet()) {
-			if (dc.getValue().dropsWithTool(biome, tool) && blockY <= dc.getValue().getMaxY(biome)
-					&& blockY >= dc.getValue().getMinY(biome)) {
+		for (Map.Entry<String, DropConfig> dce : dropConfigs.entrySet()) {
+			DropConfig dc = dce.getValue();
+			if (dc.dropsWithTool(biome, tool) && blockY <= dc.getMaxY(biome)
+					&& blockY >= dc.getMinY(biome)) {
 				
-				ToolConfig tc = dc.getValue().dropsWithToolConfig(biome, tool);
-				localChance = dc.getValue().getChance(biome) * (tc == null ? 1.0 : tc.getDropChanceModifier()) * dc.getValue().getStateChance(biome, player);
+				ToolConfig tc = dc.dropsWithToolConfig(biome, tool);
+				localChance = dc.getChance(biome) * (tc == null ? 1.0 : tc.getDropChanceModifier()) * dc.getStateChance(biome, player);
 				
-				/*DIAGNOSTICS*HiddenOre.getPlugin().getLogger()
-						.log(Level.INFO, "Base chance {0}| tool mod {1}| totalChance {2}| tc {3}",
-						new Object[] {Double.toString(dc.getValue().getChance(biome)),
-								Double.toString(tc == null ? 1.0 : tc.getDropChanceModifier()),
-								localChance, (tc == null ? null : tc.toString())});*/
+				VeinConfig vc = dc.getVeinNature();
+				if (vc != null) {
+					localChance *= vc.getOreChance(loc);
+					
+					/*DIAGNOSTICS*/
+					HiddenOre.getPlugin().getLogger()
+							.log(Level.INFO, "Base chance {0}| tool mod {1}| vein mod {2}| totalChance {3}| tc {4}",
+							new Object[] {Double.toString(dc.getChance(biome)),
+									Double.toString(tc == null ? 1.0 : tc.getDropChanceModifier()),
+									vc.getOreChance(loc), localChance, (tc == null ? null : tc.toString())});/**/
+				} else {
+					/*DIAGNOSTICS*/
+					HiddenOre.getPlugin().getLogger()
+							.log(Level.INFO, "Base chance {0}| tool mod {1}| totalChance {2}| tc {3}",
+							new Object[] {Double.toString(dc.getChance(biome)),
+									Double.toString(tc == null ? 1.0 : tc.getDropChanceModifier()),
+									localChance, (tc == null ? null : tc.toString())});/**/
+				}
 				
 				if (dice >= cumChance && dice < cumChance + localChance) {
-					return dc.getKey();
+					return dce.getKey();
 				}
 				cumChance += localChance;
 				counted++;

--- a/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
@@ -102,19 +102,19 @@ public class BlockConfig {
 				if (vc != null) {
 					localChance *= vc.getOreChance(loc);
 					
-					/*DIAGNOSTICS*/
+					/*DIAGNOSTICS
 					HiddenOre.getPlugin().getLogger()
 							.log(Level.INFO, "Base chance {0}| tool mod {1}| vein mod {2}| totalChance {3}| tc {4}",
 							new Object[] {Double.toString(dc.getChance(biome)),
 									Double.toString(tc == null ? 1.0 : tc.getDropChanceModifier()),
-									vc.getOreChance(loc), localChance, (tc == null ? null : tc.toString())});/**/
+									vc.getOreChance(loc), localChance, (tc == null ? null : tc.toString())});*/
 				} else {
-					/*DIAGNOSTICS*/
+					/*DIAGNOSTICS
 					HiddenOre.getPlugin().getLogger()
 							.log(Level.INFO, "Base chance {0}| tool mod {1}| totalChance {2}| tc {3}",
 							new Object[] {Double.toString(dc.getChance(biome)),
 									Double.toString(tc == null ? 1.0 : tc.getDropChanceModifier()),
-									localChance, (tc == null ? null : tc.toString())});/**/
+									localChance, (tc == null ? null : tc.toString())});*/
 				}
 				
 				if (dice >= cumChance && dice < cumChance + localChance) {

--- a/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/BlockConfig.java
@@ -21,7 +21,6 @@ public class BlockConfig {
 	public boolean suppressDrops;
 	private Map<String, DropConfig> dropConfigs;
 	private String prefix;
-	private BlockConfigMode preferMode;
 
 	public BlockConfig(NamespacedKey material, boolean dropMultiple, boolean suppressDrops, String prefix, Collection<NamespacedKey> validGenTypes) {
 		this.material = material;
@@ -30,17 +29,8 @@ public class BlockConfig {
 		this.dropConfigs = new HashMap<String, DropConfig>();
 		this.prefix = prefix;
 		this.validGenTypes = validGenTypes;
-		this.preferMode = BlockConfigMode.both;
 	}
 	
-	public void setPreferMode(BlockConfigMode preferMode) {
-		this.preferMode = preferMode;
-	}
-	
-	public BlockConfigMode getPreferMode() {
-		return this.preferMode;
-	}
-
 	public NamespacedKey getMaterialKey() {
 		return this.material;
 	}
@@ -89,14 +79,6 @@ public class BlockConfig {
 
 	public DropConfig getDropConfig(String drop) {
 		return dropConfigs.get(drop);
-	}
-	
-	public boolean getForceVisibleTransform(String drop) {
-		DropConfig dc = getDropConfig(drop);
-		if (dc == null) return false;
-		VeinConfig vc = dc.getVeinNature();
-		if (vc == null) return false;
-		return vc.getForceVisibleTransform();
 	}
 
 	public String getDropConfig(double dice, String biome, ItemStack tool, Player player, Location loc) {

--- a/src/main/java/com/github/devotedmc/hiddenore/BlockConfigMode.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/BlockConfigMode.java
@@ -1,7 +1,0 @@
-package com.github.devotedmc.hiddenore;
-
-public enum BlockConfigMode {
-	vein,
-	drop,
-	both
-}

--- a/src/main/java/com/github/devotedmc/hiddenore/BlockConfigMode.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/BlockConfigMode.java
@@ -1,0 +1,7 @@
+package com.github.devotedmc.hiddenore;
+
+public enum BlockConfigMode {
+	vein,
+	drop,
+	both
+}

--- a/src/main/java/com/github/devotedmc/hiddenore/Config.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/Config.java
@@ -264,15 +264,17 @@ public final class Config {
 				String cBlockName = block.getString("material");
 				List<NamespacedKey> cBlockKeys = new ArrayList<NamespacedKey>();
 				if (cBlockName == null) {
-					List<String> cBlockNames = block.getStringList("materials");
-					if (cBlockNames == null || cBlockNames.isEmpty()) {
+					ConfigurationSection cBlockNames = block.getConfigurationSection("materials");
+					if (cBlockNames == null) {
 						HiddenOre.getPlugin().getLogger().warning("Failed to find material or materials for " + sourceBlock);
 						continue;
 					} else {
-						for (String cBlockN : cBlockNames) {
-							Material cBlockMat = Material.getMaterial(cBlockN);
+						for (String cBlockN : cBlockNames.getKeys(false)) {
+							ConfigurationSection cBlockS = cBlockNames.getConfigurationSection(cBlockN);
+							String cBlockName2 = cBlockS.getString("material");
+							Material cBlockMat = Material.getMaterial(cBlockName2);
 							if (cBlockMat == null) {
-								HiddenOre.getPlugin().getLogger().warning("Failed to find material for " + cBlockName);
+								HiddenOre.getPlugin().getLogger().warning("Failed to find material for " + cBlockName2);
 								continue;
 							} else {
 								cBlockKeys.add(cBlockMat.getKey());

--- a/src/main/java/com/github/devotedmc/hiddenore/Config.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/Config.java
@@ -372,10 +372,28 @@ public final class Config {
 		boolean transformDropIfFails = drop.getBoolean("transformDropIfFails", false);
 		int transformMaxDropsIfFails = drop.getInt("transformMaxDropsIfFails", 1);
 		String command = drop.getString("command", null);
+		
+		VeinConfig veinNature = null;
+		ConfigurationSection veinNatureConfig = drop.getConfigurationSection("veinNature");
+		if (veinNatureConfig != null) {
+			long densitySeed = veinNatureConfig.getLong("densitySeed", 1);
+			long heightSeed = veinNatureConfig.getLong("heightSeed", 2);
+			double density = veinNatureConfig.getDouble("density", 1.0);
+			double maxSpan = veinNatureConfig.getDouble("maxSpan", 0.0);
+			double densityBonus = veinNatureConfig.getDouble("densityBonus", 0.0);
+			double areaHeight = veinNatureConfig.getDouble("areaHeight", 1.0);
+			double areaSpan = veinNatureConfig.getDouble("areaSpan", 0.0);
+			double heightLength = veinNatureConfig.getDouble("heightLength", 1.0);
+			double densityLength = veinNatureConfig.getDouble("densityLength", 1.0);
+			boolean forceVisible = veinNatureConfig.getBoolean("forceVisibleTransform", false);
+			
+			veinNature = new VeinConfig(densitySeed, heightSeed, density, maxSpan, densityBonus, areaHeight, areaSpan,
+					heightLength, densityLength, forceVisible);
+		}
 
 		DropConfig dc = new DropConfig(sourceDrop, DropItemConfig.transform(items), command,
 				transformIfAble, transformDropIfFails, transformMaxDropsIfFails,
-				dPrefix, grabLimits(drop, new DropLimitsConfig()));
+				dPrefix, grabLimits(drop, new DropLimitsConfig()), veinNature);
 
 		ConfigurationSection biomes = drop.getConfigurationSection("biomes");
 		if (biomes != null) {

--- a/src/main/java/com/github/devotedmc/hiddenore/DropConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/DropConfig.java
@@ -20,10 +20,11 @@ public class DropConfig {
 	public boolean dropIfTransformFails;
 	public int maxDropsIfTransformFails;
 	private Map<String, DropLimitsConfig> biomeLimits;
+	private VeinConfig veinNature;
 
 	public DropConfig(String dropName, List<DropItemConfig> drops, String command, boolean transformIfAble, 
 			boolean dropIfTransformFails, int maxDropsIfTransformFails, String prefix, 
-			DropLimitsConfig limits) {
+			DropLimitsConfig limits, VeinConfig veinNature) {
 		this.dropName = dropName;
 		this.drops = drops;
 		this.command = command;
@@ -32,6 +33,11 @@ public class DropConfig {
 		this.maxDropsIfTransformFails = maxDropsIfTransformFails;
 		this.limits = limits;
 		this.biomeLimits = new HashMap<String, DropLimitsConfig>();
+		this.veinNature = veinNature;
+	}
+	
+	public VeinConfig getVeinNature() {
+		return veinNature;
 	}
 
 	public void addBiomeLimits(String biome, DropLimitsConfig limits) {

--- a/src/main/java/com/github/devotedmc/hiddenore/VeinConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/VeinConfig.java
@@ -1,0 +1,65 @@
+package com.github.devotedmc.hiddenore;
+
+import org.bukkit.Location;
+import org.bukkit.util.noise.NoiseGenerator;
+import org.bukkit.util.noise.SimplexNoiseGenerator;
+
+/**
+ * Borrowed wholesale, for now, from CivClassic vein's approach branch.
+ * Might change over time.
+ * 
+ * @author TealNerd, ProgrammerDan
+ *
+ */
+public class VeinConfig {
+	
+	private double density;
+	private double maxSpan;
+	private double densityBonus;
+	private double areaHeight;
+	private double areaSpan;
+	private double heightLength;
+	private double densityLength;
+	
+	private boolean forceVisibleTransform;
+
+	private NoiseGenerator heightNoiseGen;
+	private NoiseGenerator densityNoiseGen;
+	
+	
+	public VeinConfig(long densitySeed, long heightSeed, double density, double maxSpan, double densityBonus, double areaHeight,
+			double areaSpan, double heightLength, double densityLength, boolean forceVisibleTransform) {
+		this.density = density;
+		this.maxSpan = maxSpan;
+		this.densityBonus = densityBonus;
+		this.areaHeight = areaHeight;
+		this.areaSpan = areaSpan;
+		this.heightLength = heightLength;
+		this.densityLength = densityLength;
+		this.heightNoiseGen = new SimplexNoiseGenerator(heightSeed);
+		this.densityNoiseGen = new SimplexNoiseGenerator(densitySeed);
+		this.forceVisibleTransform = forceVisibleTransform;
+	}
+
+	public double getOreChance(Location loc) {
+		return getOreChance(loc.getX(), loc.getBlockY(), loc.getZ());
+	}
+	
+	public double getOreChance(double x, int y, double z) {
+		double chance = Math.abs(y-getVeinHeight(x, z));
+		if(chance > maxSpan) return 0;
+		return ((Math.cos(chance * Math.PI / maxSpan) + 1) / 2) * getVeinDensity(x, z);
+	}
+	
+	private double getVeinHeight(double x, double z) {
+		return heightNoiseGen.noise(x / heightLength, z / heightLength) * areaSpan + areaHeight;
+	}
+	
+	private double getVeinDensity(double x, double z) {
+		return (densityNoiseGen.noise(x / densityLength, z / densityLength) + densityBonus) * density;
+	}
+	
+	public boolean getForceVisibleTransform() {
+		return this.forceVisibleTransform;
+	}
+}

--- a/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
@@ -31,6 +31,7 @@ import com.github.devotedmc.hiddenore.DropConfig;
 import com.github.devotedmc.hiddenore.HiddenOre;
 import com.github.devotedmc.hiddenore.Config;
 import com.github.devotedmc.hiddenore.ToolConfig;
+import com.github.devotedmc.hiddenore.VeinConfig;
 import com.github.devotedmc.hiddenore.events.HiddenOreEvent;
 import com.github.devotedmc.hiddenore.events.HiddenOreGenerateEvent;
 import com.github.devotedmc.hiddenore.util.FakePlayer;
@@ -145,6 +146,11 @@ public class BlockBreakListener implements Listener {
 				double dropChance = dc.getChance(biomeName) 
 						* (dropModifier == null ? 1.0 : dropModifier.getDropChanceModifier())
 						* dc.getStateChance(biomeName, p);
+				
+				VeinConfig vc = dc.getVeinNature(); // handle vein externally
+				if (vc != null) {
+					dropChance *= vc.getOreChance(b.getLocation());
+				}
 
 				// Random check to decide whether or not the special drop should be dropped
 				if (dropChance > Math.random()) {
@@ -161,7 +167,7 @@ public class BlockBreakListener implements Listener {
 			}
 		} else {
 			String drop = bc.getDropConfig(Math.random(), biomeName, inMainHand, 
-					p, b.getLocation().getBlockY());
+					p, b.getLocation()); // handles vein internally
 
 			if (drop != null) {
 				DropConfig dc = bc.getDropConfig(drop);
@@ -193,6 +199,12 @@ public class BlockBreakListener implements Listener {
 		double xpChance = dc.getXPChance(biomeName) 
 				* (dropModifier == null ? 1.0 : dropModifier.getDropChanceModifier())
 				* dc.getStateChance(biomeName, p);
+		
+		VeinConfig vc = dc.getVeinNature();
+		if (vc != null) {
+			xpChance *= vc.getOreChance(loc);
+		}
+		
 		if (xpChance > Math.random()) {
 			int toXP = dc.renderXP(biomeName, dropModifier);
 			if (toXP > 0) {
@@ -252,8 +264,8 @@ public class BlockBreakListener implements Listener {
 		}
 		
 		runCommand(player, dropConfig.command);
-		// now try for XP
-		
+
+		// xp handled upstream
 
 		return true;
 	}
@@ -313,15 +325,23 @@ public class BlockBreakListener implements Listener {
 		int cPlace = 0;
 		double cAttempt = 0;
 		boolean tryFacing = false; // pick a facing block of attacked block
+		int forceFacing = -1;
+		VeinConfig vc = dropConfig.getVeinNature();
 		Block origin = sourceLocation.getBlock();
 		for (ItemStack xform : items) {
 			Material sample = xform.getType();
 			Material expressed = sample;
-			maxWalk += xform.getAmount() * Config.getTransformAttemptMultiplier();
+			forceFacing = (vc == null ? -1 : (vc.getForceVisibleTransform() ? 0 : -1 )); // do index traverse on visible faces
+			// to ensure overall fairness but density in discovery, we add walk attempts to cover forced facing reveal
+			// to make sure we test them all before moving on.
+			maxWalk += xform.getAmount() * Config.getTransformAttemptMultiplier() + (forceFacing == 0 ? visibleFaces.length : 0);
 			cPlace = xform.getAmount();
 			while (cPlace > 0 && maxWalk > 0) {
 				Block walk = null;
-				if (!tryFacing) {
+				if (forceFacing >= -1 && forceFacing < visibleFaces.length) {
+					walk = origin.getRelative(this.visibleFaces[forceFacing++]);
+					tryFacing = true;
+				} else if (!tryFacing) {
 					// Try to ensure something of the generation is visible.
 					walk = this.getVisibleFacing(origin);
 				} else {

--- a/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/listeners/BlockBreakListener.java
@@ -338,14 +338,16 @@ public class BlockBreakListener implements Listener {
 			cPlace = xform.getAmount();
 			while (cPlace > 0 && maxWalk > 0) {
 				Block walk = null;
-				if (forceFacing >= -1 && forceFacing < visibleFaces.length) {
-					walk = origin.getRelative(this.visibleFaces[forceFacing++]);
+				if (forceFacing > -1 && forceFacing < visibleFaces.length) {
+					walk = this.getVisibleFacing(origin);//origin.getRelative(this.visibleFaces[forceFacing++]);
+					forceFacing++;
 					tryFacing = true;
 				} else if (!tryFacing) {
 					// Try to ensure something of the generation is visible.
 					walk = this.getVisibleFacing(origin);
 				} else {
 					// Use a kind of radial bloom to try to place the discovered blocks.
+					// expose u0, uA (multiplier on cube root of attempts) in config
 					double z = Math.random() * 2.0 - 1.0;
 					double zsq = Math.sqrt(1-Math.pow(z, 2));
 					double u = 0.5 + Math.floor(Math.cbrt(cAttempt++));

--- a/src/main/resources/config-veins.yml
+++ b/src/main/resources/config-veins.yml
@@ -15,47 +15,47 @@ caveOres: false
 # Keep this value small, or performance _will_ suffer.
 transform_attempt_multiplier: 3
 clear_ores:
- main_world:
-  world: world
-  replace:
-  - IRON_ORE
-  - REDSTONE_ORE
-  - GOLD_ORE
-  - COAL_ORE
-  - DIAMOND_ORE
-  - EMERALD_ORE
-  - LAPIS_ORE
-  with: STONE
- end_world:
-  world: world_nether
-  replace: 
-  - NETHER_QUARTZ_ORE
-  with: NETHERRACK
+  main_world:
+    world: world
+    replace:
+    - IRON_ORE
+    - REDSTONE_ORE
+    - GOLD_ORE
+    - COAL_ORE
+    - DIAMOND_ORE
+    - EMERALD_ORE
+    - LAPIS_ORE
+    with: STONE
+  end_world:
+    world: world_nether
+    replace: 
+    - NETHER_QUARTZ_ORE
+    with: NETHERRACK
 tools:
- # Giving a tool ignore:all:true will make it the default catchall, if specified in a config.
- # So if you have a "default" behavior you want for any non-specified tool, use that.
- # Great for things that are often broken by hand or with random crap held, like dirt, sand, gravel.
- # "ignore" section is ignored but "modifiers" section will be applied.
- anything:
-  ignore:
-   all: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
+  # Giving a tool ignore:all:true will make it the default catchall, if specified in a config.
+  # So if you have a "default" behavior you want for any non-specified tool, use that.
+  # Great for things that are often broken by hand or with random crap held, like dirt, sand, gravel.
+  # "ignore" section is ignored but "modifiers" section will be applied.
+  anything:
+    ignore:
+      all: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
 states:
 # These allow modification of drop chance based on the player's state
  # Give each "set" of modifications a name
   # For each specific type of player state (haste / fatigue / nausea, etc) provide an array
   # The chance is picked from this array by matching Level of effect to the named effect.
   # So for [0.8, 0.5] -- haste I has a 0.8 reduction, haste II has a 0.5 reduction.
- generalRebalance:
-  haste: [0.9, 0.7]
-  fatigue: [1.1, 1.3]
-  nausea: [0.5, 0.3, 0.1]
-  luck: [2.0, 3.0, 4.0]
-  badluck: [0.1, 0.01, 0.002]
-  blindness: [0.0, 0.0, 0.0]
+  generalRebalance:
+    haste: [0.9, 0.7]
+    fatigue: [1.1, 1.3]
+    nausea: [0.5, 0.3, 0.1]
+    luck: [2.0, 3.0, 4.0]
+    badluck: [0.1, 0.01, 0.002]
+    blindness: [0.0, 0.0, 0.0]
 drops:
  # As of 1.3.2, you can now specify a command to run instead of (or in addition to) drops.
  fancy_cmd:
@@ -112,29 +112,32 @@ drops:
   veinNature:
    # Controls the "intensity" of the noise function, or, the overall likelihood at peak noise
    density: .5
-   # This controls in some fashion the tailoff distribution across the vein span region, such that
-   # it helps to form a cosine distribution centered around the "height" of the 
-   # vein as determined by areaHeight, areaSpan, and the height seed.
-   maxSpan: 65
-   # After raw density [0-1] is computed, add this value to the computation, then multiply by density.
+   # This controls in the tailoff distribution across the vein span region, such that
+   # it helps to form a cosine distribution centered around the "center" of the 
+   # vein as bounded by areaHeight, areaSpan, and the height seed.
+   maxSpan: 10
+   # After raw density [-1,1] is computed, add this value to the computation, then multiply by density.
    densityBonus: 0.1
-   # Offset Y for vein. The vein midpoints definitely start strictly ABOVE this offset
-   # subject to drop's minY, maxY
-   areaHeight: 10
+   # Offset Y for vein. This is the midpoint for vein centers.
+   areaHeight: 30
    # Preferred radius/spread on Y for vein. Vein will be  
-   # again subject to drop's minY maxY. Full distribution vertically is
-   # controlled by some mix of areaHeight as lower bound for picking a midpoint,
-   # areaSpan to help choose a midpoint using the noise function,
-   # then maxSpan as max distance from the chosen midpoint that has a 
+   # again subject to drop's minY maxY. Full vein center distribution vertically is
+   # controlled by [areaHeight - areaSpan, areaHeight + areaSpan]
+   # 
+   # Full spread is [areaHeight - areaSpan - maxSpan, areaHeight + areaSpan + maxSpan]
+   # where maxSpan is max distance from the chosen midpoint that has a 
    # chance of being in the vein, subject to a cosine function decaying out
    # from the center, with point of highest chance at the chosen midpoint, and
    # lowest chance at maxSpan distance away from that midpoint.
-   areaSpan: 50
-   # This is a divider against the "height noise map". Basically, larger values results in more severe vein height
-   # transitions. smaller values, more gradual.
+   #
+   # All of these spans are constrained by [minY, maxY]
+   areaSpan: 20
+   # This is a divider against the "height noise map". Basically, smaller values results in more severe vein height
+   # transitions. heigher values, more gradual.
    heightLength: 0.5
-   # This is a divider against the "density noise map". larger values result in smaller overall veins in terms of
-   # density. Conversely, small values; larger regions of density.
+   # This is a divider against the "density noise map". smaller values result in smaller overall veins in terms of
+   # density. Conversely, large values; larger regions of density. Some trial and error is necessary to determine the 
+   # relative "feel" of the resulting vein structures.
    densityLength: 2
    # A number indicating the height seed to use in the noise function.
    heightSeed: 129382
@@ -168,16 +171,6 @@ drops:
   minAmount: 1
   maxAmount: 4
   state: generalRebalance
-  veinNature:
-   density: 
-   maxSpan:
-   densityBonus:
-   areaHeight:
-   areaSpan:
-   heightLength:
-   densityLength:
-   heightSeed:
-   densitySeed:
 blocks:
  # This defines for which types of things drops are possible. Give each "block config" a friendly name.
  stone:
@@ -219,6 +212,8 @@ blocks:
   # Note, use "materials" instead of "material" (1.5.1) for it to work (pick just one -- no mixnmatch here)
   materials:
    andesite:
+    # we preserve this structure in anticipation of future features for 1.13 and beyond, where we can specify block
+    # natures and otherwise limit or enhance our recognition of specific blocks and block types.
     material: ANDESITE
    diorite:
     material: DIORITE

--- a/src/main/resources/config-veins.yml
+++ b/src/main/resources/config-veins.yml
@@ -1,0 +1,371 @@
+# This file shows an example of how to do veins for HiddenOre backed by noise generators.
+# Portions of this are deeply inspired by the work by TealNerd in his CivClassic fork of
+#  HiddenOre.
+prefix: You found a hidden vein ore!
+alert_user: true
+list_drops: true
+debug: false
+# As of 1.4.0, a new tracking was added that keeps a per-block record of "activity" and discards revealed blocks as
+# sources for transformation. This tracking requires a LOT of space and memory, compared to ordinary exploit prevention.
+# It's mostly a quality of life addition. Set this to false to turn it off. Default (if unset) is to turn it on.
+map_save_active: false
+ignore_silktouch: true
+caveOres: false
+# For each potential transformation in a generate event, how many attempts at most will be made?
+# Keep this value small, or performance _will_ suffer.
+transform_attempt_multiplier: 3
+clear_ores:
+ main_world:
+  world: world
+  replace:
+  - IRON_ORE
+  - REDSTONE_ORE
+  - GOLD_ORE
+  - COAL_ORE
+  - DIAMOND_ORE
+  - EMERALD_ORE
+  - LAPIS_ORE
+  with: STONE
+ end_world:
+  world: world_nether
+  replace: 
+  - NETHER_QUARTZ_ORE
+  with: NETHERRACK
+tools:
+ # Giving a tool ignore:all:true will make it the default catchall, if specified in a config.
+ # So if you have a "default" behavior you want for any non-specified tool, use that.
+ # Great for things that are often broken by hand or with random crap held, like dirt, sand, gravel.
+ # "ignore" section is ignored but "modifiers" section will be applied.
+ anything:
+  ignore:
+   all: true
+  modifiers:
+   dropChance: 1.0
+   minAmount: 0.0
+   maxAmount: 0.0
+states:
+# These allow modification of drop chance based on the player's state
+ # Give each "set" of modifications a name
+  # For each specific type of player state (haste / fatigue / nausea, etc) provide an array
+  # The chance is picked from this array by matching Level of effect to the named effect.
+  # So for [0.8, 0.5] -- haste I has a 0.8 reduction, haste II has a 0.5 reduction.
+ generalRebalance:
+  haste: [0.9, 0.7]
+  fatigue: [1.1, 1.3]
+  nausea: [0.5, 0.3, 0.1]
+  luck: [2.0, 3.0, 4.0]
+  badluck: [0.1, 0.01, 0.002]
+  blindness: [0.0, 0.0, 0.0]
+drops:
+ # As of 1.3.2, you can now specify a command to run instead of (or in addition to) drops.
+ fancy_cmd:
+  minY: 1
+  maxY: 255
+  chance: 0.0001
+  command: '/give %player% iron_ingot 1'
+  # You can specify tool and biome, and state modifiers like any other drop.
+  tools:
+   - wood_pickaxe
+ # Here we define all the potential drops for this material/subtype. Give each "drop config" a friendly name.
+ coal_ore:
+  # Package is the list of ConfigurationSerializeable ItemStack that should constitutes this drop.
+  # You can specify one or _many_ items, to emulate the true "drop chest" experience.
+  package:
+   - ==: org.bukkit.inventory.ItemStack
+     v: 1
+     type: COAL_ORE
+     # Amount is _not_ ignored. Use this as the "base" multipler. This amount will be multiplied by the randomly chosen "amount" configured
+     # later and modified per tool and biome.
+     amount: 1
+  # A String list here of all the tool friendly-names that you defined in the root "tools" section which can trigger this drop.
+  tools:
+   - wood_pickaxe
+   - stone_pickaxe
+   - iron_pickaxe
+   - gold_pickaxe
+   - diamond_pickaxe
+  # lowest Y in the map that this drop can be found.
+  # acts as "areaHeight" if areaHeight isn't set on veinNature.
+  minY: 1
+  # highest Y in the map that this drop can be found.
+  maxY: 131
+  # Base chance for this drop. This is percent chance / 100 -- so 1 is 100%, 0.1 is 10%, and 0.01 is 1%.
+  chance: 0.01
+  # multipliers of package's amount. Specify these separately or "amount" for a fixed value. If min and max are used,
+  #  and this drop is selected, then a random value between min and max is chosen, after min and max are adjusted
+  #  by biome or tool.
+  minAmount: 2
+  maxAmount: 8
+  # Instead of dropping the package, attempts to transform nearby blocks of the same type as triggered this
+  # drop into the package. If portions of the drop can't be transformed, they are still just dropped.
+  # Default is false. 
+  transformIfAble: true
+  # If for some reason transformation can't find a place to do its magic, should we use normal drop behavior?
+  # Default is false.
+  transformDropIfFails: false
+  # If we do use normal drop behavior, what's the maximum drop size (after being constrained by maxAmount above)
+  # Default is 1.
+  transformMaxDropsIfFails: 1
+  # Describes which state by name to use from the `states` section above.
+  state: generalRebalance
+  # drop configurations can also have a vein nature 
+  veinNature:
+   # Controls the "intensity" of the noise function, or, the overall likelihood at peak noise
+   density: .5
+   # This controls in some fashion the tailoff distribution across the vein span region, such that
+   # it helps to form a cosine distribution centered around the "height" of the 
+   # vein as determined by areaHeight, areaSpan, and the height seed.
+   maxSpan: 65
+   # After raw density [0-1] is computed, add this value to the computation, then multiply by density.
+   densityBonus: 0.1
+   # Offset Y for vein. The vein midpoints definitely start strictly ABOVE this offset
+   # subject to drop's minY, maxY
+   areaHeight: 10
+   # Preferred radius/spread on Y for vein. Vein will be  
+   # again subject to drop's minY maxY. Full distribution vertically is
+   # controlled by some mix of areaHeight as lower bound for picking a midpoint,
+   # areaSpan to help choose a midpoint using the noise function,
+   # then maxSpan as max distance from the chosen midpoint that has a 
+   # chance of being in the vein, subject to a cosine function decaying out
+   # from the center, with point of highest chance at the chosen midpoint, and
+   # lowest chance at maxSpan distance away from that midpoint.
+   areaSpan: 50
+   # This is a divider against the "height noise map". Basically, larger values results in more severe vein height
+   # transitions. smaller values, more gradual.
+   heightLength: 0.5
+   # This is a divider against the "density noise map". larger values result in smaller overall veins in terms of
+   # density. Conversely, small values; larger regions of density.
+   densityLength: 2
+   # A number indicating the height seed to use in the noise function.
+   heightSeed: 129382
+   # A number indicating the density seed to use
+   densitySeed: 384837
+   # Basically, if a vein block condition is met, check all immediate neighboring, and now visible blocks
+   # if they should be revealed, subject to the drop & block configurations.
+   # revealed as well
+   forceVisibleTransform: true
+ iron_ore:
+  package:
+   - ==: org.bukkit.inventory.ItemStack
+     v: 1
+     type: IRON_ORE
+     amount: 1
+  tools:
+   - stone_pickaxe
+   - iron_pickaxe
+   - diamond_pickaxe
+  # Chance for XP to drop when this gen/drop occurs
+  # you can add this section to "biomes" as well for unique biome-level drops
+  # chance and amount are modified by tool.
+  xp:
+   # standard amount config; amount for "always" value, minAmount/maxAmount for randomized size
+   amount: 1
+   # Chance of XP to generate; this is a separate chance and computed separately for XP
+   chance: 1.0
+  minY: 1
+  maxY: 67
+  chance: 0.007
+  minAmount: 1
+  maxAmount: 4
+  state: generalRebalance
+  veinNature:
+   density: 
+   maxSpan:
+   densityBonus:
+   areaHeight:
+   areaSpan:
+   heightLength:
+   densityLength:
+   heightSeed:
+   densitySeed:
+blocks:
+ # This defines for which types of things drops are possible. Give each "block config" a friendly name.
+ stone:
+  # Name the 'root type' of this block config using its Bukkit material name.
+  material: STONE
+  # If any of the drops for this block have Transform mode enabled, you can specify a list of blocks that,
+  # in addition to the block defined above, can be transformed.
+  validTransforms:
+    # Use the same style of definition as above. Throwaway label, then 'material' and either 'allTypes' true, or define a "types" list.
+    cobblestone:
+      material: COBBLESTONE
+    dirt:
+      material: DIRT
+    andesite:
+      material: ANDESITE
+    diorite:
+      material: DIORITE
+    granite:
+      material: GRANITE
+  # Drop mode. Multiple drops means that every possible drop is evaluated separately and all RNG-winners are grouped together in one big drop.
+  #   false is more of a "classic" mode, where every possible drop's chance is accumulated, then a single Random number is generated and
+  #   evaluated, resulting in either one or no drop.
+  dropMultiple: false
+  dropList:
+   # As of 1.5.1, you can now specify a list of drops, configured in a master drops section, to apply.
+   - fancy_cmd
+   - coal_ore
+   - gold_ore
+   - diamond_ore
+   - lapis_ore
+   - iron_ore
+   - redstone_ore
+   - emerald_ore
+   # As of 1.5.1, you can skip this if you use the dropList above.
+  #drops:
+ # As of 1.5.1 you can indicate a list of materials that all share this config,
+ # and it will be replicated for each one.
+ aggregates:
+  # Note, use "materials" instead of "material" (1.5.1) for it to work (pick just one -- no mixnmatch here)
+  materials:
+   andesite:
+    material: ANDESITE
+   diorite:
+    material: DIORITE
+   granite: 
+    material: GRANITE
+  validTransforms:
+    cobblestone:
+      material: COBBLESTONE
+    dirt:
+      material: DIRT
+    stone:
+      material: STONE
+    diorite:
+      material: DIORITE
+    granite:
+      material: GRANITE
+    andesite:
+      material: ANDESITE
+  dropMultiple: false
+  # As of 1.5.1 you can mix and match new dropList and prior drops
+  dropList:
+   - fancy_cmd
+  drops:
+   coal_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: COAL_ORE
+       amount: 1
+    tools:
+     - wood_pickaxe
+     - stone_pickaxe
+     - iron_pickaxe
+     - gold_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 131
+    chance: 0.01
+    minAmount: 2
+    maxAmount: 8
+    transformIfAble: true
+    transformDropIfFails: false
+    transformMaxDropsIfFails: 1
+    state: generalRebalance
+   iron_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: IRON_ORE
+       amount: 1
+    tools:
+     - stone_pickaxe
+     - iron_pickaxe
+     - diamond_pickaxe
+    xp:
+     amount: 1
+     chance: 1.0
+    minY: 1
+    maxY: 67
+    chance: 0.007
+    minAmount: 1
+    maxAmount: 4
+    state: hasteDebuff
+   gold_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: GOLD_ORE
+       amount: 1
+    tools:
+     - iron_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 33
+    chance: 0.001437
+    minAmount: 1
+    maxAmount: 4
+    state: generalRebalance
+   diamond_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: DIAMOND_ORE
+       amount: 1
+    tools:
+     - iron_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 15
+    chance: 0.0005427
+    minAmount: 1
+    maxAmount: 3
+    state: generalRebalance
+   redstone_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: REDSTONE_ORE
+       amount: 1
+    tools:
+     - iron_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 15
+    chance: 0.01025
+    minAmount: 1
+    maxAmount: 4
+    state: generalRebalance
+   lapis_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: LAPIS_ORE
+       amount: 1
+    tools:
+     - stone_pickaxe
+     - iron_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 33
+    chance: 0.000597
+    minAmount: 1
+    maxAmount: 3
+    state: fatigueBuff
+   emerald_ore:
+    package:
+     - ==: org.bukkit.inventory.ItemStack
+       v: 1
+       type: EMERALD_ORE
+       amount: 1
+    tools:
+     - iron_pickaxe
+     - diamond_pickaxe
+    minY: 1
+    maxY: 32
+    chance: 0.0
+    minAmount: 1
+    maxAmount: 2
+    state: generalRebalance
+    biomes:
+     EXTREME_HILLS:
+      chance: 0.001437
+      state: fatigueBuff
+     MUTATED_EXTREME_HILLS:
+      chance: 0.001437
+      state: hasteDebuff
+     EXTREME_HILLS_WITH_TREES:
+      chance: 0.001437
+     MUTATED_EXTREME_HILLS_WITH_TREES:
+      chance: 0.001437

--- a/src/main/resources/config-veins.yml
+++ b/src/main/resources/config-veins.yml
@@ -8,6 +8,7 @@ debug: false
 # As of 1.4.0, a new tracking was added that keeps a per-block record of "activity" and discards revealed blocks as
 # sources for transformation. This tracking requires a LOT of space and memory, compared to ordinary exploit prevention.
 # It's mostly a quality of life addition. Set this to false to turn it off. Default (if unset) is to turn it on.
+# Example for 1.5.2 is to set to false, as it will incur some additional runtime impact.
 map_save_active: false
 ignore_silktouch: true
 caveOres: false

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,8 @@ debug: false
 # As of 1.4.0, a new tracking was added that keeps a per-block record of "activity" and discards revealed blocks as
 # sources for transformation. This tracking requires a LOT of space and memory, compared to ordinary exploit prevention.
 # It's mostly a quality of life addition. Set this to false to turn it off. Default (if unset) is to turn it on.
-map_save_active: true
+# Example for 1.5.2 is to set to false, as it will incur some additional runtime impact.
+map_save_active: false
 ignore_silktouch: true
 caveOres: false
 # For each potential transformation in a generate event, how many attempts at most will be made?


### PR DESCRIPTION
Noise based veins. Based in large part on effort by TealNerd in his CivClassic fork, and in PR of the same nature.

Biggest differences are this layers vein handling in alongside drops and transforms, both are supported like any normal drop.

As well, biomes, tools, player states, and y limits are respected when evaluating noise-based veins. For ease in portability, vein configurations are identical to those in CivClassic.

Please note the new config-vein.yml for examples, and note that much has changed (including, most significantly, 1.13 support).

Thanks again @TealNerd for the first go at veins and the basis this is built on and @soerxpso for your originating work.