### PR TITLE
#37 feature - ore/state permission based modifiers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+				 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+				 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
@@ -12,7 +12,7 @@
 
 	<groupId>com.github.devotedmc</groupId>
 	<artifactId>hiddenore</artifactId>
-	<version>1.7.2</version>
+	<version>1.7.3</version>
 	<name>HiddenOre</name>
 
 	<repositories>
@@ -20,12 +20,16 @@
 			<id>civ-github-repo</id>
 			<url>https://raw.githubusercontent.com/CivClassic/artifacts/master/</url>
 		</repository>
+		<repository>
+			<id>papermc</id>
+			<url>https://papermc.io/repo/repository/maven-public/</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
 		<dependency>
 			<groupId>com.destroystokyo.paper</groupId>
-			<artifactId>paper</artifactId>
+			<artifactId>paper-api</artifactId>
 			<version>1.16.4-R0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>

--- a/src/main/java/com/github/devotedmc/hiddenore/PlayerStateConfig.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/PlayerStateConfig.java
@@ -1,6 +1,7 @@
 package com.github.devotedmc.hiddenore;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.entity.Player;
 import org.bukkit.potion.PotionEffect;
@@ -35,6 +36,7 @@ public class PlayerStateConfig {
 	public List<Double> luckRates;
 	public List<Double> blindnessRates;
 	public List<Double> badluckRates;
+	public List<Map.Entry<String, Double>> permRates;
 	
 	/**
 	 * All states are applied successively
@@ -69,6 +71,13 @@ public class PlayerStateConfig {
 			} else if (effect.getType().equals(PotionEffectType.UNLUCK)) { // unluck
 				if (badluckRates != null && idx < badluckRates.size()) {
 					presentRate *= badluckRates.get(idx);
+				}
+			}
+		}
+		if (permRates != null) {
+			for (Map.Entry<String, Double> ent : permRates) {
+				if (player.hasPermission(ent.getKey())) {
+					presentRate *= ent.getValue();
 				}
 			}
 		}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -26,7 +26,7 @@ clear_ores:
   with: STONE
  end_world:
   world: world_nether
-  replace: 
+  replace:
   - NETHER_QUARTZ_ORE
   with: NETHERRACK
 tools:
@@ -43,7 +43,7 @@ tools:
    maxAmount: 0.0
  # Give the item a "friendly name" that you'll use in the "tools" section of each drop config.
  wood_pickaxe:
-  # Open an issue if the config-advanced.yml data doesn't give you enough to go on to 
+  # Open an issue if the config-advanced.yml data doesn't give you enough to go on to
   #  design the template of your desire.
   template:
    ==: org.bukkit.inventory.ItemStack
@@ -146,6 +146,7 @@ tools:
    maxAmount: 0.0
 states:
 # These allow modification of drop chance based on the player's state
+# Drops must be assigned a state for the effects to take effect.
  hasteDebuff:
  # Give each "set" of modifications a name
   haste: [0.8, 0.5]
@@ -161,6 +162,12 @@ states:
   luck: [2.0, 3.0, 4.0]
   badluck: [0.1, 0.01, 0.002]
   blindness: [0.0, 0.0, 0.0]
+ permsState:
+   # Define permission based modifiers in the state's permissions section.
+   # Each permission requires both a permission and a modifier.
+   permissions:
+     - permission: exampleperm.givemeloot
+       modifier: 10.0
 drops:
  # As of 1.3.2, you can now specify a command to run instead of (or in addition to) drops.
  fancy_cmd:
@@ -202,7 +209,7 @@ drops:
   maxAmount: 8
   # Instead of dropping the package, attempts to transform nearby blocks of the same type as triggered this
   # drop into the package. If portions of the drop can't be transformed, they are still just dropped.
-  # Default is false. 
+  # Default is false.
   transformIfAble: true
   # If for some reason transformation can't find a place to do its magic, should we use normal drop behavior?
   # Default is false.
@@ -371,7 +378,7 @@ blocks:
     material: ANDESITE
    diorite:
     material: DIORITE
-   granite: 
+   granite:
     material: GRANITE
   validTransforms:
     cobblestone:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,550 +13,550 @@ caveOres: false
 # Keep this value small, or performance _will_ suffer.
 transform_attempt_multiplier: 3
 clear_ores:
- main_world:
-  world: world
-  replace:
-  - IRON_ORE
-  - REDSTONE_ORE
-  - GOLD_ORE
-  - COAL_ORE
-  - DIAMOND_ORE
-  - EMERALD_ORE
-  - LAPIS_ORE
-  with: STONE
- end_world:
-  world: world_nether
-  replace:
-  - NETHER_QUARTZ_ORE
-  with: NETHERRACK
+  main_world:
+    world: world
+    replace:
+      - IRON_ORE
+      - REDSTONE_ORE
+      - GOLD_ORE
+      - COAL_ORE
+      - DIAMOND_ORE
+      - EMERALD_ORE
+      - LAPIS_ORE
+    with: STONE
+  end_world:
+    world: world_nether
+    replace:
+      - NETHER_QUARTZ_ORE
+    with: NETHERRACK
 tools:
- # Giving a tool ignore:all:true will make it the default catchall, if specified in a config.
- # So if you have a "default" behavior you want for any non-specified tool, use that.
- # Great for things that are often broken by hand or with random crap held, like dirt, sand, gravel.
- # "ignore" section is ignored but "modifiers" section will be applied.
- anything:
-  ignore:
-   all: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
- # Give the item a "friendly name" that you'll use in the "tools" section of each drop config.
- wood_pickaxe:
-  # Open an issue if the config-advanced.yml data doesn't give you enough to go on to
-  #  design the template of your desire.
-  template:
-   ==: org.bukkit.inventory.ItemStack
-   v: 1
-   type: WOODEN_PICKAXE
-   amount: 1
-  ignore:
-   # Ignore the amount held.
-   amount: true
-   # Ignore the durability of the item held.
-   durability: true
-   # Ignore all enchantments.
-   enchants: true
-   # Ignore any enchantments not specified in the template
-   otherEnchants: true
-   # Ignore the specific lvl of the enchantments considered
-   enchantsLvl: true
-   # Ignore any differences in lore
-   lore: true
-   # Ignore any differences in display name.
-   name: true
-  modifiers:
-   # Multiplier to drop chance; applied _after_ biome computation
-   dropChance: 1.0
-   # Adder on minimum drop size; so, drop config min + this min.
-   minAmount: 0.0
-   # Adder on maximum drop size; so, drop config max + this max. Both can be negative.
-   maxAmount: 0.0
- gold_pickaxe:
-  template:
-   ==: org.bukkit.inventory.ItemStack
-   v: 1
-   type: GOLDEN_PICKAXE
-   amount: 1
-  ignore:
-   amount: true
-   durability: true
-   enchants: true
-   otherEnchants: true
-   enchantsLvl: true
-   lore: true
-   name: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
- iron_pickaxe:
-  template:
-   ==: org.bukkit.inventory.ItemStack
-   v: 1
-   type: IRON_PICKAXE
-   amount: 1
-  ignore:
-   amount: true
-   durability: true
-   enchants: true
-   otherEnchants: true
-   enchantsLvl: true
-   lore: true
-   name: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
- stone_pickaxe:
-  template:
-   ==: org.bukkit.inventory.ItemStack
-   v: 1
-   type: STONE_PICKAXE
-   amount: 1
-  ignore:
-   amount: true
-   durability: true
-   enchants: true
-   otherEnchants: true
-   enchantsLvl: true
-   lore: true
-   name: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
- diamond_pickaxe:
-  template:
-   ==: org.bukkit.inventory.ItemStack
-   v: 1
-   type: DIAMOND_PICKAXE
-   amount: 1
-  ignore:
-   amount: true
-   durability: true
-   enchants: true
-   otherEnchants: true
-   enchantsLvl: true
-   lore: true
-   name: true
-  modifiers:
-   dropChance: 1.0
-   minAmount: 0.0
-   maxAmount: 0.0
+  # Giving a tool ignore:all:true will make it the default catchall, if specified in a config.
+  # So if you have a "default" behavior you want for any non-specified tool, use that.
+  # Great for things that are often broken by hand or with random crap held, like dirt, sand, gravel.
+  # "ignore" section is ignored but "modifiers" section will be applied.
+  anything:
+    ignore:
+      all: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
+  # Give the item a "friendly name" that you'll use in the "tools" section of each drop config.
+  wood_pickaxe:
+    # Open an issue if the config-advanced.yml data doesn't give you enough to go on to
+    #  design the template of your desire.
+    template:
+      ==: org.bukkit.inventory.ItemStack
+      v: 1
+      type: WOODEN_PICKAXE
+      amount: 1
+    ignore:
+      # Ignore the amount held.
+      amount: true
+      # Ignore the durability of the item held.
+      durability: true
+      # Ignore all enchantments.
+      enchants: true
+      # Ignore any enchantments not specified in the template
+      otherEnchants: true
+      # Ignore the specific lvl of the enchantments considered
+      enchantsLvl: true
+      # Ignore any differences in lore
+      lore: true
+      # Ignore any differences in display name.
+      name: true
+    modifiers:
+      # Multiplier to drop chance; applied _after_ biome computation
+      dropChance: 1.0
+      # Adder on minimum drop size; so, drop config min + this min.
+      minAmount: 0.0
+      # Adder on maximum drop size; so, drop config max + this max. Both can be negative.
+      maxAmount: 0.0
+  gold_pickaxe:
+    template:
+      ==: org.bukkit.inventory.ItemStack
+      v: 1
+      type: GOLDEN_PICKAXE
+      amount: 1
+    ignore:
+      amount: true
+      durability: true
+      enchants: true
+      otherEnchants: true
+      enchantsLvl: true
+      lore: true
+      name: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
+  iron_pickaxe:
+    template:
+      ==: org.bukkit.inventory.ItemStack
+      v: 1
+      type: IRON_PICKAXE
+      amount: 1
+    ignore:
+      amount: true
+      durability: true
+      enchants: true
+      otherEnchants: true
+      enchantsLvl: true
+      lore: true
+      name: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
+  stone_pickaxe:
+    template:
+      ==: org.bukkit.inventory.ItemStack
+      v: 1
+      type: STONE_PICKAXE
+      amount: 1
+    ignore:
+      amount: true
+      durability: true
+      enchants: true
+      otherEnchants: true
+      enchantsLvl: true
+      lore: true
+      name: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
+  diamond_pickaxe:
+    template:
+      ==: org.bukkit.inventory.ItemStack
+      v: 1
+      type: DIAMOND_PICKAXE
+      amount: 1
+    ignore:
+      amount: true
+      durability: true
+      enchants: true
+      otherEnchants: true
+      enchantsLvl: true
+      lore: true
+      name: true
+    modifiers:
+      dropChance: 1.0
+      minAmount: 0.0
+      maxAmount: 0.0
 states:
-# These allow modification of drop chance based on the player's state
-# Drops must be assigned a state for the effects to take effect.
- hasteDebuff:
- # Give each "set" of modifications a name
-  haste: [0.8, 0.5]
-  # For each specific type of player state (haste / fatigue / nausea, etc) provide an array
-  # The chance is picked from this array by matching Level of effect to the named effect.
-  # So for [0.8, 0.5] -- haste I has a 0.8 reduction, haste II has a 0.5 reduction.
- fatigueBuff:
-  fatigue: [1.2, 1.5]
- generalRebalance:
-  haste: [0.9, 0.7]
-  fatigue: [1.1, 1.3]
-  nausea: [0.5, 0.3, 0.1]
-  luck: [2.0, 3.0, 4.0]
-  badluck: [0.1, 0.01, 0.002]
-  blindness: [0.0, 0.0, 0.0]
- permsState:
-   # Define permission based modifiers in the state's permissions section.
-   # Each permission requires both a permission and a modifier.
-   permissions:
-     - permission: exampleperm.givemeloot
-       modifier: 10.0
+  # These allow modification of drop chance based on the player's state
+  # Drops must be assigned a state for the effects to take effect.
+  hasteDebuff:
+    # Give each "set" of modifications a name
+    haste: [ 0.8, 0.5 ]
+    # For each specific type of player state (haste / fatigue / nausea, etc) provide an array
+    # The chance is picked from this array by matching Level of effect to the named effect.
+    # So for [0.8, 0.5] -- haste I has a 0.8 reduction, haste II has a 0.5 reduction.
+  fatigueBuff:
+    fatigue: [ 1.2, 1.5 ]
+  generalRebalance:
+    haste: [ 0.9, 0.7 ]
+    fatigue: [ 1.1, 1.3 ]
+    nausea: [ 0.5, 0.3, 0.1 ]
+    luck: [ 2.0, 3.0, 4.0 ]
+    badluck: [ 0.1, 0.01, 0.002 ]
+    blindness: [ 0.0, 0.0, 0.0 ]
+  permsState:
+    # Define permission based modifiers in the state's permissions section.
+    # Each permission requires both a permission and a modifier.
+    permissions:
+      - permission: exampleperm.givemeloot
+        modifier: 10.0
 drops:
- # As of 1.3.2, you can now specify a command to run instead of (or in addition to) drops.
- fancy_cmd:
-  minY: 1
-  maxY: 255
-  chance: 0.0001
-  command: 'give %player% iron_ingot 1'
-  # You can specify tool and biome, and state modifiers like any other drop.
-  tools:
-   - wood_pickaxe
- # Here we define all the potential drops for this material/subtype. Give each "drop config" a friendly name.
- coal_ore:
-  # Package is the list of ConfigurationSerializeable ItemStack that should constitutes this drop.
-  # You can specify one or _many_ items, to emulate the true "drop chest" experience.
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: COAL_ORE
-     # Amount is _not_ ignored. Use this as the "base" multipler. This amount will be multiplied by the randomly chosen "amount" configured
-     # later and modified per tool and biome.
-     amount: 1
-  # A String list here of all the tool friendly-names that you defined in the root "tools" section which can trigger this drop.
-  tools:
-   - wood_pickaxe
-   - stone_pickaxe
-   - iron_pickaxe
-   - gold_pickaxe
-   - diamond_pickaxe
-  # lowest Y in the map that this drop can be found.
-  minY: 1
-  # highest Y in the map that this drop can be found.
-  maxY: 131
-  # Base chance for this drop. This is percent chance / 100 -- so 1 is 100%, 0.1 is 10%, and 0.01 is 1%.
-  chance: 0.01
-  # multipliers of package's amount. Specify these separately or "amount" for a fixed value. If min and max are used,
-  #  and this drop is selected, then a random value between min and max is chosen, after min and max are adjusted
-  #  by biome or tool.
-  minAmount: 2
-  maxAmount: 8
-  # Instead of dropping the package, attempts to transform nearby blocks of the same type as triggered this
-  # drop into the package. If portions of the drop can't be transformed, they are still just dropped.
-  # Default is false.
-  transformIfAble: true
-  # If for some reason transformation can't find a place to do its magic, should we use normal drop behavior?
-  # Default is false.
-  transformDropIfFails: false
-  # If we do use normal drop behavior, what's the maximum drop size (after being constrained by maxAmount above)
-  # Default is 1.
-  transformMaxDropsIfFails: 1
-  # Describes which state by name to use from the `states` section above.
-  state: generalRebalance
- iron_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: IRON_ORE
-     amount: 1
-  tools:
-   - stone_pickaxe
-   - iron_pickaxe
-   - diamond_pickaxe
-  # Chance for XP to drop when this gen/drop occurs
-  # you can add this section to "biomes" as well for unique biome-level drops
-  # chance and amount are modified by tool.
-  xp:
-   # standard amount config; amount for "always" value, minAmount/maxAmount for randomized size
-   amount: 1
-   # Chance of XP to generate; this is a separate chance and computed separately for XP
-   chance: 1.0
-  minY: 1
-  maxY: 67
-  chance: 0.007
-  minAmount: 1
-  maxAmount: 4
-  state: hasteDebuff
- gold_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: GOLD_ORE
-     amount: 1
-  tools:
-   - iron_pickaxe
-   - diamond_pickaxe
-  minY: 1
-  maxY: 33
-  chance: 0.001437
-  minAmount: 1
-  maxAmount: 4
-  state: generalRebalance
- diamond_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: DIAMOND_ORE
-     amount: 1
-  tools:
-   - iron_pickaxe
-   - diamond_pickaxe
-  minY: 1
-  maxY: 15
-  chance: 0.0005427
-  minAmount: 1
-  maxAmount: 3
-  state: generalRebalance
- redstone_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: REDSTONE_ORE
-     amount: 1
-  tools:
-   - iron_pickaxe
-   - diamond_pickaxe
-  minY: 1
-  maxY: 15
-  chance: 0.01025
-  minAmount: 1
-  maxAmount: 4
-  state: generalRebalance
- lapis_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: LAPIS_ORE
-     amount: 1
-  tools:
-   - stone_pickaxe
-   - iron_pickaxe
-   - diamond_pickaxe
-  minY: 1
-  maxY: 33
-  chance: 0.000597
-  minAmount: 1
-  maxAmount: 3
-  state: fatigueBuff
- emerald_ore:
-  package:
-   - ==: org.bukkit.inventory.ItemStack
-     v: 1
-     type: EMERALD_ORE
-     amount: 1
-  tools:
-   - iron_pickaxe
-   - diamond_pickaxe
-  minY: 1
-  maxY: 32
-  chance: 0.0
-  minAmount: 1
-  maxAmount: 2
-  state: generalRebalance
-  # Biomes can modify the chance rate. Anything specified in biome _replaces_ the base chance or min/max amounts,
-  #  unlike tools which modify those values after biome is resolved.
-  # States can be defined per biome as well, and similarly replaces base state assignment when within that biome.
-  biomes:
-   EXTREME_HILLS:
-    chance: 0.001437
-    state: fatigueBuff
-   MUTATED_EXTREME_HILLS:
-    chance: 0.001437
-    state: hasteDebuff
-   EXTREME_HILLS_WITH_TREES:
-    chance: 0.001437
-   MUTATED_EXTREME_HILLS_WITH_TREES:
-    chance: 0.001437
-
-blocks:
- # This defines for which types of things drops are possible. Give each "block config" a friendly name.
- stone:
-  # Name the 'root type' of this block config using its Bukkit material name.
-  material: STONE
-  # If any of the drops for this block have Transform mode enabled, you can specify a list of blocks that,
-  # in addition to the block defined above, can be transformed.
-  validTransforms:
-    # Use the same style of definition as above. Throwaway label, then 'material' and either 'allTypes' true, or define a "types" list.
-    cobblestone:
-      material: COBBLESTONE
-    dirt:
-      material: DIRT
-    andesite:
-      material: ANDESITE
-    diorite:
-      material: DIORITE
-    granite:
-      material: GRANITE
-  # Drop mode. Multiple drops means that every possible drop is evaluated separately and all RNG-winners are grouped together in one big drop.
-  #   false is more of a "classic" mode, where every possible drop's chance is accumulated, then a single Random number is generated and
-  #   evaluated, resulting in either one or no drop.
-  dropMultiple: false
-  dropList:
-   # As of 1.5.1, you can now specify a list of drops, configured in a master drops section, to apply.
-   - fancy_cmd
-   - coal_ore
-   - gold_ore
-   - diamond_ore
-   - lapis_ore
-   - iron_ore
-   - redstone_ore
-   - emerald_ore
-   # As of 1.5.1, you can skip this if you use the dropList above.
-  #drops:
- # As of 1.5.1 you can indicate a list of materials that all share this config,
- # and it will be replicated for each one.
- aggregates:
-  # Note, use "materials" instead of "material" (1.5.1) for it to work (pick just one -- no mixnmatch here)
-  materials:
-   andesite:
-    material: ANDESITE
-   diorite:
-    material: DIORITE
-   granite:
-    material: GRANITE
-  validTransforms:
-    cobblestone:
-      material: COBBLESTONE
-    dirt:
-      material: DIRT
-    stone:
-      material: STONE
-    diorite:
-      material: DIORITE
-    granite:
-      material: GRANITE
-    andesite:
-      material: ANDESITE
-  dropMultiple: false
-  # As of 1.5.1 you can mix and match new dropList and prior drops
-  dropList:
-   - fancy_cmd
-  drops:
-   coal_ore:
-    package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: COAL_ORE
-       amount: 1
-    tools:
-     - wood_pickaxe
-     - stone_pickaxe
-     - iron_pickaxe
-     - gold_pickaxe
-     - diamond_pickaxe
+  # As of 1.3.2, you can now specify a command to run instead of (or in addition to) drops.
+  fancy_cmd:
     minY: 1
+    maxY: 255
+    chance: 0.0001
+    command: 'give %player% iron_ingot 1'
+    # You can specify tool and biome, and state modifiers like any other drop.
+    tools:
+      - wood_pickaxe
+  # Here we define all the potential drops for this material/subtype. Give each "drop config" a friendly name.
+  coal_ore:
+    # Package is the list of ConfigurationSerializeable ItemStack that should constitutes this drop.
+    # You can specify one or _many_ items, to emulate the true "drop chest" experience.
+    package:
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: COAL_ORE
+        # Amount is _not_ ignored. Use this as the "base" multipler. This amount will be multiplied by the randomly chosen "amount" configured
+        # later and modified per tool and biome.
+        amount: 1
+    # A String list here of all the tool friendly-names that you defined in the root "tools" section which can trigger this drop.
+    tools:
+      - wood_pickaxe
+      - stone_pickaxe
+      - iron_pickaxe
+      - gold_pickaxe
+      - diamond_pickaxe
+    # lowest Y in the map that this drop can be found.
+    minY: 1
+    # highest Y in the map that this drop can be found.
     maxY: 131
+    # Base chance for this drop. This is percent chance / 100 -- so 1 is 100%, 0.1 is 10%, and 0.01 is 1%.
     chance: 0.01
+    # multipliers of package's amount. Specify these separately or "amount" for a fixed value. If min and max are used,
+    #  and this drop is selected, then a random value between min and max is chosen, after min and max are adjusted
+    #  by biome or tool.
     minAmount: 2
     maxAmount: 8
+    # Instead of dropping the package, attempts to transform nearby blocks of the same type as triggered this
+    # drop into the package. If portions of the drop can't be transformed, they are still just dropped.
+    # Default is false.
     transformIfAble: true
+    # If for some reason transformation can't find a place to do its magic, should we use normal drop behavior?
+    # Default is false.
     transformDropIfFails: false
+    # If we do use normal drop behavior, what's the maximum drop size (after being constrained by maxAmount above)
+    # Default is 1.
     transformMaxDropsIfFails: 1
+    # Describes which state by name to use from the `states` section above.
     state: generalRebalance
-   iron_ore:
+  iron_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: IRON_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: IRON_ORE
+        amount: 1
     tools:
-     - stone_pickaxe
-     - iron_pickaxe
-     - diamond_pickaxe
+      - stone_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
+    # Chance for XP to drop when this gen/drop occurs
+    # you can add this section to "biomes" as well for unique biome-level drops
+    # chance and amount are modified by tool.
     xp:
-     amount: 1
-     chance: 1.0
+      # standard amount config; amount for "always" value, minAmount/maxAmount for randomized size
+      amount: 1
+      # Chance of XP to generate; this is a separate chance and computed separately for XP
+      chance: 1.0
     minY: 1
     maxY: 67
     chance: 0.007
     minAmount: 1
     maxAmount: 4
     state: hasteDebuff
-   gold_ore:
+  gold_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: GOLD_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: GOLD_ORE
+        amount: 1
     tools:
-     - iron_pickaxe
-     - diamond_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
     minY: 1
     maxY: 33
     chance: 0.001437
     minAmount: 1
     maxAmount: 4
     state: generalRebalance
-   diamond_ore:
+  diamond_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: DIAMOND_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: DIAMOND_ORE
+        amount: 1
     tools:
-     - iron_pickaxe
-     - diamond_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
     minY: 1
     maxY: 15
     chance: 0.0005427
     minAmount: 1
     maxAmount: 3
     state: generalRebalance
-   redstone_ore:
+  redstone_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: REDSTONE_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: REDSTONE_ORE
+        amount: 1
     tools:
-     - iron_pickaxe
-     - diamond_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
     minY: 1
     maxY: 15
     chance: 0.01025
     minAmount: 1
     maxAmount: 4
     state: generalRebalance
-   lapis_ore:
+  lapis_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: LAPIS_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: LAPIS_ORE
+        amount: 1
     tools:
-     - stone_pickaxe
-     - iron_pickaxe
-     - diamond_pickaxe
+      - stone_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
     minY: 1
     maxY: 33
     chance: 0.000597
     minAmount: 1
     maxAmount: 3
     state: fatigueBuff
-   emerald_ore:
+  emerald_ore:
     package:
-     - ==: org.bukkit.inventory.ItemStack
-       v: 1
-       type: EMERALD_ORE
-       amount: 1
+      - ==: org.bukkit.inventory.ItemStack
+        v: 1
+        type: EMERALD_ORE
+        amount: 1
     tools:
-     - iron_pickaxe
-     - diamond_pickaxe
+      - iron_pickaxe
+      - diamond_pickaxe
     minY: 1
     maxY: 32
     chance: 0.0
     minAmount: 1
     maxAmount: 2
     state: generalRebalance
+    # Biomes can modify the chance rate. Anything specified in biome _replaces_ the base chance or min/max amounts,
+    #  unlike tools which modify those values after biome is resolved.
+    # States can be defined per biome as well, and similarly replaces base state assignment when within that biome.
     biomes:
-     EXTREME_HILLS:
-      chance: 0.001437
-      state: fatigueBuff
-     MUTATED_EXTREME_HILLS:
-      chance: 0.001437
-      state: hasteDebuff
-     EXTREME_HILLS_WITH_TREES:
-      chance: 0.001437
-     MUTATED_EXTREME_HILLS_WITH_TREES:
-      chance: 0.001437
+      EXTREME_HILLS:
+        chance: 0.001437
+        state: fatigueBuff
+      MUTATED_EXTREME_HILLS:
+        chance: 0.001437
+        state: hasteDebuff
+      EXTREME_HILLS_WITH_TREES:
+        chance: 0.001437
+      MUTATED_EXTREME_HILLS_WITH_TREES:
+        chance: 0.001437
+
+blocks:
+  # This defines for which types of things drops are possible. Give each "block config" a friendly name.
+  stone:
+    # Name the 'root type' of this block config using its Bukkit material name.
+    material: STONE
+    # If any of the drops for this block have Transform mode enabled, you can specify a list of blocks that,
+    # in addition to the block defined above, can be transformed.
+    validTransforms:
+      # Use the same style of definition as above. Throwaway label, then 'material' and either 'allTypes' true, or define a "types" list.
+      cobblestone:
+        material: COBBLESTONE
+      dirt:
+        material: DIRT
+      andesite:
+        material: ANDESITE
+      diorite:
+        material: DIORITE
+      granite:
+        material: GRANITE
+    # Drop mode. Multiple drops means that every possible drop is evaluated separately and all RNG-winners are grouped together in one big drop.
+    #   false is more of a "classic" mode, where every possible drop's chance is accumulated, then a single Random number is generated and
+    #   evaluated, resulting in either one or no drop.
+    dropMultiple: false
+    dropList:
+      # As of 1.5.1, you can now specify a list of drops, configured in a master drops section, to apply.
+      - fancy_cmd
+      - coal_ore
+      - gold_ore
+      - diamond_ore
+      - lapis_ore
+      - iron_ore
+      - redstone_ore
+      - emerald_ore
+      # As of 1.5.1, you can skip this if you use the dropList above.
+    #drops:
+  # As of 1.5.1 you can indicate a list of materials that all share this config,
+  # and it will be replicated for each one.
+  aggregates:
+    # Note, use "materials" instead of "material" (1.5.1) for it to work (pick just one -- no mixnmatch here)
+    materials:
+      andesite:
+        material: ANDESITE
+      diorite:
+        material: DIORITE
+      granite:
+        material: GRANITE
+    validTransforms:
+      cobblestone:
+        material: COBBLESTONE
+      dirt:
+        material: DIRT
+      stone:
+        material: STONE
+      diorite:
+        material: DIORITE
+      granite:
+        material: GRANITE
+      andesite:
+        material: ANDESITE
+    dropMultiple: false
+    # As of 1.5.1 you can mix and match new dropList and prior drops
+    dropList:
+      - fancy_cmd
+    drops:
+      coal_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: COAL_ORE
+            amount: 1
+        tools:
+          - wood_pickaxe
+          - stone_pickaxe
+          - iron_pickaxe
+          - gold_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 131
+        chance: 0.01
+        minAmount: 2
+        maxAmount: 8
+        transformIfAble: true
+        transformDropIfFails: false
+        transformMaxDropsIfFails: 1
+        state: generalRebalance
+      iron_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: IRON_ORE
+            amount: 1
+        tools:
+          - stone_pickaxe
+          - iron_pickaxe
+          - diamond_pickaxe
+        xp:
+          amount: 1
+          chance: 1.0
+        minY: 1
+        maxY: 67
+        chance: 0.007
+        minAmount: 1
+        maxAmount: 4
+        state: hasteDebuff
+      gold_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: GOLD_ORE
+            amount: 1
+        tools:
+          - iron_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 33
+        chance: 0.001437
+        minAmount: 1
+        maxAmount: 4
+        state: generalRebalance
+      diamond_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: DIAMOND_ORE
+            amount: 1
+        tools:
+          - iron_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 15
+        chance: 0.0005427
+        minAmount: 1
+        maxAmount: 3
+        state: generalRebalance
+      redstone_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: REDSTONE_ORE
+            amount: 1
+        tools:
+          - iron_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 15
+        chance: 0.01025
+        minAmount: 1
+        maxAmount: 4
+        state: generalRebalance
+      lapis_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: LAPIS_ORE
+            amount: 1
+        tools:
+          - stone_pickaxe
+          - iron_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 33
+        chance: 0.000597
+        minAmount: 1
+        maxAmount: 3
+        state: fatigueBuff
+      emerald_ore:
+        package:
+          - ==: org.bukkit.inventory.ItemStack
+            v: 1
+            type: EMERALD_ORE
+            amount: 1
+        tools:
+          - iron_pickaxe
+          - diamond_pickaxe
+        minY: 1
+        maxY: 32
+        chance: 0.0
+        minAmount: 1
+        maxAmount: 2
+        state: generalRebalance
+        biomes:
+          EXTREME_HILLS:
+            chance: 0.001437
+            state: fatigueBuff
+          MUTATED_EXTREME_HILLS:
+            chance: 0.001437
+            state: hasteDebuff
+          EXTREME_HILLS_WITH_TREES:
+            chance: 0.001437
+          MUTATED_EXTREME_HILLS_WITH_TREES:
+            chance: 0.001437
 
 # Example of new worlds config, here we explicitly specify only a single block drop for this world.
 worlds:
- world_nether:
-  blocks:
-   netherrack:
-    material: NETHERRACK
-    dropMultiple: false
-    drops:
-     quartz_ore:
-      package:
-       - ==: org.bukkit.inventory.ItemStack
-         v: 1
-         type: NETHER_QUARTZ_ORE
-         amount: 1
-      tools:
-       - wood_pickaxe
-       - stone_pickaxe
-       - iron_pickaxe
-       - gold_pickaxe
-       - diamond_pickaxe
-      minY: 1
-      maxY: 125
-      chance: 0.0
-      minAmount: 1
-      maxAmount: 2
-      biomes:
-       HELL:
-        # You can also modify the minimum Y values for a specific biome giving you complete control over where things can be found.
-        minY: 1
-        maxY: 125
-        chance: 0.007
+  world_nether:
+    blocks:
+      netherrack:
+        material: NETHERRACK
+        dropMultiple: false
+        drops:
+          quartz_ore:
+            package:
+              - ==: org.bukkit.inventory.ItemStack
+                v: 1
+                type: NETHER_QUARTZ_ORE
+                amount: 1
+            tools:
+              - wood_pickaxe
+              - stone_pickaxe
+              - iron_pickaxe
+              - gold_pickaxe
+              - diamond_pickaxe
+            minY: 1
+            maxY: 125
+            chance: 0.0
+            minAmount: 1
+            maxAmount: 2
+            biomes:
+              HELL:
+                # You can also modify the minimum Y values for a specific biome giving you complete control over where things can be found.
+                minY: 1
+                maxY: 125
+                chance: 0.007
 # Example w/ custom prefixes.
 # sand:
 #  material: SAND
@@ -594,23 +594,23 @@ worlds:
 #  for now you can specify replacement names for your drops here. This values are only used in messaging to users about
 #  their drops and are not applied to the items dropped.
 pretty_names:
- DIAMOND: Diamond
- IRON_INGOT: Iron ingot
- GOLD_INGOT: Gold ingot
- QUARTZ: Quartz
- EMERALD: Emerald
- PRISMARINE_SHARD: Prismarine Shard
- REDSTONE: Redstone
- DIAMOND_ORE: Diamond Ore
- IRON_ORE: Iron Ore
- GOLD_ORE: Gold Ore
- QUARTZ_ORE: Quartz Ore
- EMERALD_ORE: Emerald Ore
- PRISMARINE: Prismarine
- REDSTONE_ORE: Redstone Ore
- LAPIS_ORE: Lapis Lazuli Ore
- COAL_ORE: Coal Ore
- COAL: Coal
- NETHERRACK: Netherrack
- # if the base type has subtypes, just specify those subtypes as a list. If you specify one, you'll need to specify all used subtypes.
- LAPIS_LAZULI: Lapis Lazuli
+  DIAMOND: Diamond
+  IRON_INGOT: Iron ingot
+  GOLD_INGOT: Gold ingot
+  QUARTZ: Quartz
+  EMERALD: Emerald
+  PRISMARINE_SHARD: Prismarine Shard
+  REDSTONE: Redstone
+  DIAMOND_ORE: Diamond Ore
+  IRON_ORE: Iron Ore
+  GOLD_ORE: Gold Ore
+  QUARTZ_ORE: Quartz Ore
+  EMERALD_ORE: Emerald Ore
+  PRISMARINE: Prismarine
+  REDSTONE_ORE: Redstone Ore
+  LAPIS_ORE: Lapis Lazuli Ore
+  COAL_ORE: Coal Ore
+  COAL: Coal
+  NETHERRACK: Netherrack
+  # if the base type has subtypes, just specify those subtypes as a list. If you specify one, you'll need to specify all used subtypes.
+  LAPIS_LAZULI: Lapis Lazuli


### PR DESCRIPTION
Implements suggested changes from #37 
Also adds Paper's maven repo to the POM and uses paper-api instead of a locally built paper server.
Also also fixes the godawful spacing in the default config.yml.