### PR TITLE
Prevent reload from inadvertently closing the plugin class loader

### DIFF
--- a/src/main/java/com/github/devotedmc/hiddenore/commands/CommandHandler.java
+++ b/src/main/java/com/github/devotedmc/hiddenore/commands/CommandHandler.java
@@ -1,9 +1,13 @@
 package com.github.devotedmc.hiddenore.commands;
 
+import com.github.devotedmc.hiddenore.BlockConfig;
+import com.github.devotedmc.hiddenore.Config;
+import com.github.devotedmc.hiddenore.DropConfig;
+import com.github.devotedmc.hiddenore.DropItemConfig;
+import com.github.devotedmc.hiddenore.HiddenOre;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
 import org.bukkit.Bukkit;
 import org.bukkit.NamespacedKey;
 import org.bukkit.command.Command;
@@ -11,12 +15,6 @@ import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
-
-import com.github.devotedmc.hiddenore.BlockConfig;
-import com.github.devotedmc.hiddenore.Config;
-import com.github.devotedmc.hiddenore.DropConfig;
-import com.github.devotedmc.hiddenore.DropItemConfig;
-import com.github.devotedmc.hiddenore.HiddenOre;
 
 /**
  * Management and maintenance commands
@@ -93,7 +91,7 @@ public class CommandHandler implements CommandExecutor {
 						return true;
 					}
 				} else {
-					Bukkit.getPluginManager().disablePlugin(plugin);
+					Bukkit.getPluginManager().disablePlugin(plugin, false);
 					Bukkit.getPluginManager().enablePlugin(plugin);
 					sender.sendMessage("HiddenOre reloaded");
 					return true;


### PR DESCRIPTION
Prevent reload from inadvertently closing the plugin class loader which causes config behaviour change between startup/reload.

When the plugin class loader is closed, calls to getResource will always return null. Because of this, the default config will always be null. If a section is left out of the config it is defaulted to the values in the default config. This means that if someone leaves out say the `blocks` section, startup will cause the blocks section to be populated with the blocks section from the default config. Reloading using `hiddenore` will then close the class loader, and when reading the config in a second time the defaults won't be applied leading to some very confusing behaviour.